### PR TITLE
テストの見直し (主にmedium)

### DIFF
--- a/functions/src/domain/task.ts
+++ b/functions/src/domain/task.ts
@@ -14,16 +14,18 @@ export const TaskSchema = z.object({
 
 export type Task = z.infer<typeof TaskSchema>;
 
-export const toTask = (taskRecord: TaskItem): Task => {
+export const toTask = (item: TaskItem): Task => {
+  const interimTask = {
+    id: item.taskId,
+    title: item.title,
+    description: item.description,
+    completed: item.completed,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+
   try {
-    return {
-      id: taskRecord.taskId,
-      title: taskRecord.title,
-      description: taskRecord.description,
-      completed: taskRecord.completed,
-      createdAt: taskRecord.createdAt,
-      updatedAt: taskRecord.updatedAt,
-    };
+    return TaskSchema.parse(interimTask);
   } catch (error) {
     throw new TaskConversionError('Failed to convert TaskRecord to Task');
   }

--- a/functions/src/infrastructure/ddb/factory/ddb-error-handler.ts
+++ b/functions/src/infrastructure/ddb/factory/ddb-error-handler.ts
@@ -5,18 +5,15 @@ import {
   DdbValidationError,
 } from '../errors/ddb-errors';
 
-export const ddbErrorHandler = (originalError: Error) => {
-  switch (originalError.name) {
+export const ddbErrorHandler = (error: Error) => {
+  switch (error.name) {
     case 'ResourceNotFoundException':
-      throw new DdbResourceNotFoundError(originalError.message, originalError);
+      throw new DdbResourceNotFoundError(error.message, error);
     case 'ProvisionedThroughputExceededException':
-      throw new DdbProvisionedThroughputExceededError(
-        originalError.message,
-        originalError,
-      );
+      throw new DdbProvisionedThroughputExceededError(error.message, error);
     case 'ValidationException':
-      throw new DdbValidationError(originalError.message, originalError);
+      throw new DdbValidationError(error.message, error);
     default:
-      throw new DdbInternalServerError(originalError.message, originalError);
+      throw new DdbInternalServerError(error.message, error);
   }
 };

--- a/functions/tests/helpers/tasks-table-helpers.ts
+++ b/functions/tests/helpers/tasks-table-helpers.ts
@@ -20,10 +20,10 @@ const localDynamoDB = new DynamoDBClient({
 });
 const ddbDocClient = DynamoDBDocumentClient.from(localDynamoDB);
 
-export const putTask = async (record: TaskItem): Promise<void> => {
+export const putTask = async (item: TaskItem): Promise<void> => {
   const putCommand = new PutCommand({
     TableName: TABLE_NAME,
-    Item: record,
+    Item: item,
   });
   await ddbDocClient.send(putCommand);
 };

--- a/functions/tests/helpers/tasks-table-helpers.ts
+++ b/functions/tests/helpers/tasks-table-helpers.ts
@@ -1,0 +1,72 @@
+import {
+  DynamoDBClient,
+  CreateTableCommand,
+  DeleteTableCommand,
+} from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  DeleteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { TaskItem } from '../../src/domain/taskItem';
+
+const TABLE_NAME = process.env.TASKS_TABLE_NAME;
+const REGION = process.env.AWS_REGION;
+const DYNAMODB_ENDPOINT = process.env.DYNAMODB_ENDPOINT;
+
+const localDynamoDB = new DynamoDBClient({
+  endpoint: DYNAMODB_ENDPOINT,
+  region: REGION,
+});
+const ddbDocClient = DynamoDBDocumentClient.from(localDynamoDB);
+
+export const putTask = async (record: TaskItem): Promise<void> => {
+  const putCommand = new PutCommand({
+    TableName: TABLE_NAME,
+    Item: record,
+  });
+  await ddbDocClient.send(putCommand);
+};
+
+export const deleteTask = async (sortKey: string): Promise<void> => {
+  const deleteCommand = new DeleteCommand({
+    TableName: TABLE_NAME,
+    Key: {
+      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+      taskId: sortKey,
+    },
+  });
+  await ddbDocClient.send(deleteCommand);
+};
+
+export const createTable = async (): Promise<void> => {
+  const createTableCommand = new CreateTableCommand({
+    TableName: TABLE_NAME,
+    AttributeDefinitions: [
+      {
+        AttributeName: 'userId',
+        AttributeType: 'S',
+      },
+      {
+        AttributeName: 'taskId',
+        AttributeType: 'S',
+      },
+    ],
+    KeySchema: [
+      {
+        AttributeName: 'userId',
+        KeyType: 'HASH',
+      },
+      {
+        AttributeName: 'taskId',
+        KeyType: 'RANGE',
+      },
+    ],
+    BillingMode: 'PAY_PER_REQUEST',
+  });
+  await localDynamoDB.send(createTableCommand);
+};
+
+export const deleteTable = async (): Promise<void> => {
+  await localDynamoDB.send(new DeleteTableCommand({ TableName: TABLE_NAME }));
+};

--- a/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
@@ -8,8 +8,8 @@ import {
   putTask,
 } from '../../../helpers/tasks-table-helpers';
 
-describe('fetchTaskById', () => {
-  const dummyTaskRecord: TaskItem = {
+describe('getTaskItemById', () => {
+  const dummyTaskItem: TaskItem = {
     userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
     taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
     title: 'スーパーに買い物に行く',
@@ -25,21 +25,21 @@ describe('fetchTaskById', () => {
     await deleteTable();
   });
   beforeEach(async () => {
-    await putTask(dummyTaskRecord);
+    await putTask(dummyTaskItem);
   });
   afterEach(async () => {
-    await deleteTask(dummyTaskRecord.taskId);
+    await deleteTask(dummyTaskItem.taskId);
   });
 
-  test('should return the dummy task record by task ID', async () => {
-    const taskRecord = await getTaskItemById(dummyTaskRecord.taskId);
-    expect(taskRecord).toEqual(dummyTaskRecord);
+  test('should return the dummy task item by task ID', async () => {
+    const TaskItem = await getTaskItemById(dummyTaskItem.taskId);
+    expect(TaskItem).toEqual(dummyTaskItem);
   });
 
   test('should return null if the task ID does not exist', async () => {
     const nonExistentTaskId = 'non-existent-task-id';
 
-    const taskRecord = await getTaskItemById(nonExistentTaskId);
-    expect(taskRecord).toBeNull();
+    const TaskItem = await getTaskItemById(nonExistentTaskId);
+    expect(TaskItem).toBeNull();
   });
 });

--- a/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
@@ -1,0 +1,45 @@
+import { TaskItem } from '../../../../src/domain/taskItem';
+
+import { getTaskItemById } from '../../../../src/infrastructure/ddb/tasks-table';
+import {
+  createTable,
+  deleteTable,
+  deleteTask,
+  putTask,
+} from '../../../helpers/tasks-table-helpers';
+
+describe('fetchTaskById', () => {
+  const dummyTaskRecord: TaskItem = {
+    userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+    taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '牛乳と卵を買う',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+  beforeAll(async () => {
+    await createTable();
+  });
+  afterAll(async () => {
+    await deleteTable();
+  });
+  beforeEach(async () => {
+    await putTask(dummyTaskRecord);
+  });
+  afterEach(async () => {
+    await deleteTask(dummyTaskRecord.taskId);
+  });
+
+  test('should return the dummy task record by task ID', async () => {
+    const taskRecord = await getTaskItemById(dummyTaskRecord.taskId);
+    expect(taskRecord).toEqual(dummyTaskRecord);
+  });
+
+  test('should return null if the task ID does not exist', async () => {
+    const nonExistentTaskId = 'non-existent-task-id';
+
+    const taskRecord = await getTaskItemById(nonExistentTaskId);
+    expect(taskRecord).toBeNull();
+  });
+});

--- a/functions/tests/medium/usecases/get-task-usecase.test.ts
+++ b/functions/tests/medium/usecases/get-task-usecase.test.ts
@@ -1,0 +1,43 @@
+import { Task } from '../../../src/domain/task';
+import { TaskItem } from '../../../src/domain/taskItem';
+import { getTaskUseCase } from '../../../src/usecases/get-task-usecase';
+import {
+  createTable,
+  deleteTable,
+  putTask,
+} from '../../helpers/tasks-table-helpers';
+
+describe('getTaskUseCase', () => {
+  beforeAll(async () => {
+    await createTable();
+  });
+
+  afterAll(async () => {
+    await deleteTable();
+  });
+
+  test('should return a task when it exists', async () => {
+    const dummyTaskItem: TaskItem = {
+      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+      taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+      title: 'スーパーに買い物に行く',
+      completed: false,
+      description: '牛乳と卵を買う',
+      createdAt: '2021-06-22T14:24:02.071Z',
+      updatedAt: '2021-06-22T14:24:02.071Z',
+    };
+    const expectedTask: Task = {
+      id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+      title: 'スーパーに買い物に行く',
+      completed: false,
+      description: '牛乳と卵を買う',
+      createdAt: '2021-06-22T14:24:02.071Z',
+      updatedAt: '2021-06-22T14:24:02.071Z',
+    };
+
+    await putTask(dummyTaskItem);
+    const result = await getTaskUseCase(dummyTaskItem.taskId);
+
+    expect(result).toEqual(expectedTask);
+  });
+});

--- a/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
@@ -17,7 +17,7 @@ describe('fetchTaskById', () => {
   });
 
   test('should return a task record for a valid task ID', async () => {
-    const dummyTaskRecord: TaskItem = {
+    const dummyTaskItem: TaskItem = {
       userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
       taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
       title: 'スーパーに買い物に行く',
@@ -27,7 +27,7 @@ describe('fetchTaskById', () => {
       updatedAt: '2021-06-22T14:24:02.071Z',
     };
 
-    documentMockClient.on(GetCommand).resolves({ Item: dummyTaskRecord });
+    documentMockClient.on(GetCommand).resolves({ Item: dummyTaskItem });
 
     const result = await getTaskItemById(mockTaskId);
 
@@ -40,7 +40,7 @@ describe('fetchTaskById', () => {
         taskId: mockTaskId,
       },
     });
-    expect(result).toEqual(dummyTaskRecord);
+    expect(result).toEqual(dummyTaskItem);
   });
 
   test('should return null if the task is not found', async () => {

--- a/functions/tests/small/usecases/get-task-usecase.test.ts
+++ b/functions/tests/small/usecases/get-task-usecase.test.ts
@@ -36,6 +36,8 @@ describe('getTask', () => {
     const result = await getTaskUseCase(taskId);
 
     expect(result).toEqual(expectedTask);
+    expect(getTaskItemById).toHaveBeenCalledTimes(1);
+    expect(getTaskItemById).toHaveBeenCalledWith(taskId);
   });
 
   test('should throw AppError with TASK_NOT_FOUND when the task is not found', async () => {
@@ -45,5 +47,21 @@ describe('getTask', () => {
     await expect(getTaskUseCase(taskId)).rejects.toThrowError(
       new AppError(ErrorCode.TASK_NOT_FOUND),
     );
+    expect(getTaskItemById).toHaveBeenCalledTimes(1);
+    expect(getTaskItemById).toHaveBeenCalledWith(taskId);
+  });
+
+  test('should throw AppError with TASK_CONVERSION_ERROR when the task record cannot be converted to Task', async () => {
+    const taskId = 'some-task-id';
+    const taskRecord = {
+      invalidField: 'invalidValue',
+    };
+    (getTaskItemById as jest.Mock).mockResolvedValueOnce(taskRecord);
+
+    await expect(getTaskUseCase(taskId)).rejects.toThrowError(
+      new AppError(ErrorCode.TASK_CONVERSION_ERROR),
+    );
+    expect(getTaskItemById).toHaveBeenCalledTimes(1);
+    expect(getTaskItemById).toHaveBeenCalledWith(taskId);
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest",
-    "test:path": "ts-node node_modules/.bin/jest --",
+    "test": "npm run test:s && npm run test:m",
+    "test:s": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --testPathPattern=/functions/tests/small/",
+    "test:m": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --runInBand --testPathPattern=/functions/tests/medium/",
+    "test:path": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --",
     "lint": "eslint '*/**/*.{js,ts}'",
     "lint:fix": "eslint '*/**/*.{js,ts}' --fix",
     "format": "prettier --write '*/**/*.{js,ts,json}'"


### PR DESCRIPTION
## 対応内容

- mediumサイズのテストを追加
  - ヘルパーも追加

- 不足していたsmallサイズのテストも追加
  - `TaskItem`から`Task`への変換がバグっていたので修正 

- サイズごとのテスト実行コマンドを追加
  - mediumではテストを並列実行しない
  - 単純に`npm test`だと全テストを実行 (CIはこれ)